### PR TITLE
chore: fix linting

### DIFF
--- a/src/fetchSchema.ts
+++ b/src/fetchSchema.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { writeFile } from "fs/promises";
+import { writeFile } from 'node:fs/promises';
 
 export const FILENAME = 'openapi.yaml';
 


### PR DESCRIPTION
single quotes, usage of node:fs and not fs