### PR TITLE
feat(ci): added next build after every commit

### DIFF
--- a/.github/workflows/build-next.yaml
+++ b/.github/workflows/build-next.yaml
@@ -1,0 +1,124 @@
+name: next build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+permissions:
+  contents: read
+  id-token: write  # Required for OIDC
+
+jobs:
+
+  tag:
+    name: Tagging
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      githubTag: ${{ steps.TAG_UTIL.outputs.githubTag}}
+      apiVersion: ${{ steps.TAG_UTIL.outputs.apiVersion}}
+      releaseId: ${{ steps.create_release.outputs.id}}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Generate tag utilities
+        id: TAG_UTIL
+        run: |
+            SHORT_SHA1=$(git rev-parse --short HEAD)
+            # Grab the version from package.json
+            CURRENT_VERSION=$(jq -r '.version' package.json)
+            # Remove the -next suffix if present
+            STRIPPED_VERSION=${CURRENT_VERSION%-next}
+            TAG_PATTERN=${STRIPPED_VERSION}-next.$(date +'%Y%m%d%H%M%S').${SHORT_SHA1}
+            echo "githubTag=v$TAG_PATTERN" >> ${GITHUB_OUTPUT}
+            echo "apiVersion=$TAG_PATTERN" >> ${GITHUB_OUTPUT}
+
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ steps.TAG_UTIL.outputs.githubTag }}
+          name: ${{ steps.TAG_UTIL.outputs.githubTag }}
+          draft: true
+          prerelease: true
+
+  build:
+    name: Build
+    needs: tag
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.x"
+
+      - name: Execute pnpm
+        run: pnpm install
+
+  release:
+    needs: [tag, build]
+    name: Release
+    permissions:
+      contents: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: id
+        run: echo the release id is ${{ needs.tag.outputs.releaseId}}
+
+      - name: Publish release
+        uses: StuYarrow/publish-release@01f2a1365bacd77bad861873a7fdf274ab49eefd # v1.1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          id: ${{ needs.tag.outputs.releaseId}}
+
+  publish:
+    needs: [tag, release]
+    name: Publish
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Publish to npmjs
+        run: |
+          echo "Using version ${{ needs.tag.outputs.apiVersion }}"
+          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.apiVersion }}\",#g" package.json
+          pnpm publish --provenance --tag next --no-git-checks --access public


### PR DESCRIPTION
Adds new workflow that creates next build after every commit 

See https://github.com/gastoner/mcp-registry-types/actions/runs/19892506700/job/57014597959
https://github.com/gastoner/mcp-registry-types/tags has been created, but publish fails but I guess it is OK since it is not "official" repo ?

Closes #23 