### PR TITLE
feat(ci): added next build after every commit

### DIFF
--- a/.github/workflows/npmjs-publish.yaml
+++ b/.github/workflows/npmjs-publish.yaml
@@ -1,0 +1,66 @@
+name: npmjs publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write  # Required for OIDC
+
+jobs:
+  publish:
+    name: Publish to npmjs
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Determine version and npm tag
+        id: version_info
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # Tag push: use tag version and publish to "latest"
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"  # Remove 'v' prefix
+            NPM_TAG="latest"
+            echo "Publishing tag version: $VERSION to npm tag: $NPM_TAG"
+          else
+            # Main branch push: create version with git SHA and publish to "next"
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            # Grab the base version from package.json
+            BASE_VERSION=$(jq -r '.version' package.json)
+            # Remove the -next suffix if present
+            STRIPPED_VERSION=${BASE_VERSION%-next}
+            # Create next version with timestamp and SHA
+            VERSION="${STRIPPED_VERSION}-next.$(date +'%Y%m%d%H%M%S').${SHORT_SHA}"
+            NPM_TAG="next"
+            echo "Publishing main branch version: $VERSION to npm tag: $NPM_TAG"
+          fi
+          
+          echo "version=$VERSION" >> ${GITHUB_OUTPUT}
+          echo "npm_tag=$NPM_TAG" >> ${GITHUB_OUTPUT}
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: 24 # 24.x for npm publish with OIDC
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Publish to npmjs
+        run: |
+          echo "Publishing version ${{ steps.version_info.outputs.version }} with npm tag: ${{ steps.version_info.outputs.npm_tag }}"
+          sed -i "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.version_info.outputs.version }}\",#g" package.json
+          pnpm publish --provenance --tag ${{ steps.version_info.outputs.npm_tag }} --no-git-checks --access public

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,12 +10,12 @@ on:
         description: 'Branch to use for the release'
         required: true
         default: main
+
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
 permissions:
   contents: read
-  id-token: write  # Required for OIDC
 
 jobs:
 
@@ -135,30 +135,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           id: ${{ needs.tag.outputs.releaseId}}
-
-  publish:
-    needs: [tag, release]
-    name: Publish
-    runs-on: ubuntu-24.04
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        name: Install pnpm
-        with:
-          run_install: false
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - name: Execute pnpm
-        run: pnpm install
-
-      - name: Publish to npmjs
-        run: |
-          echo "Using version ${{ needs.tag.outputs.apiVersion }}"
-          sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ needs.tag.outputs.apiVersion }}\",#g" package.json
-          pnpm publish --provenance --tag latest --no-git-checks --access public


### PR DESCRIPTION
Adds new workflow that creates next build after every commit

https://github.com/gastoner/mcp-registry-types/actions/runs/19929451395/job/57137405926

https://github.com/gastoner/mcp-registry-types/tags has been created, but publish fails but I guess it is OK since it is not "official" repo ?

Closes https://github.com/kortex-hub/mcp-registry-types/issues/23

Assisted by: Cursor