### PR TITLE
fix: removed type of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "access": "public"
   },
   "license": "MIT",
-  "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Try to link this package to https://github.com/kortex-hub/kortex/pull/827 using `pnpm link` 
Run typecheck, should not see the error here https://github.com/kortex-hub/kortex/pull/827#discussion_r2603243408